### PR TITLE
bugfix: prevent repeated string escaping

### DIFF
--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -51,6 +51,15 @@ options = {
   :skip_empty_files => true,
 }
 
+# parse string argument to boolean
+def string_to_boolean(string)
+    case string
+        when /^(true|t|yes|y|1)$/i then true
+        when /^(false|f|no|n|0)$/i then false
+        else raise "Cannot convert string to boolean: #{string}"
+    end
+end
+
 OptionParser.new { |opts|
   opts.banner = "Usage: ios-strings.rb [options]"
 
@@ -85,7 +94,7 @@ OptionParser.new { |opts|
   }
   
   opts.on("--skip-empty-files=STATE", "Whether empty files should be skipped. If true, they won't be exported. If false, the base language will be used to replace them. Currently, this refers only to the export of .strings files.") { |v|
-      options[:skip_empty_files] = v
+      options[:skip_empty_files] = string_to_boolean(v)
   }
 
   opts.on_tail("--help", "Show this message") {
@@ -195,7 +204,7 @@ def import_android(import_path)
       }
        
       if not values[:strings].empty? or not values[:arrays].empty? or not values[:plurals].empty? or not $skip_empty_files
-        map = $locales[locale] or not $skip_empty_files
+        map = $locales[locale]
         if not map
           $locales[locale] = values
         else
@@ -420,7 +429,6 @@ end
 
 def export_ios(res_path, locale)
   locale_path = res_path + "#{locale}.lproj"
-  puts "exporting #{locale}"
   FileUtils.mkdir_p(locale_path) unless File.directory?(locale_path)
 
   if not $strings_keys.empty? or not $skip_empty_files

--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -49,6 +49,7 @@ options = {
   :import => [],
   :export => [],
   :skip_empty_files => true,
+  :skip_untranslatable_strings => true,
 }
 
 # parse string argument to boolean
@@ -96,6 +97,10 @@ OptionParser.new { |opts|
   opts.on("--skip-empty-files=STATE", "Whether empty files should be skipped. If true, they won't be exported. If false, the base language will be used to replace them. Currently, this refers only to the export of .strings files.") { |v|
       options[:skip_empty_files] = string_to_boolean(v)
   }
+  
+  opts.on("--skip-untranslatable-strings=STATE", "Whether strings which are marked as translatable=false should be skipped.") { |v|
+      options[:skip_untranslatable_strings] = string_to_boolean(v)
+  }
 
   opts.on_tail("--help", "Show this message") {
     puts opts
@@ -108,6 +113,7 @@ $strings_keys = {}
 $arrays_keys = {}
 $plurals_keys = {}
 $skip_empty_files = options[:skip_empty_files]
+$skip_untranslatable_strings = options[:skip_untranslatable_strings]
 
 def import_android_string(str)
   str.gsub!(/^"(.*)"$/, '\1')
@@ -147,7 +153,7 @@ def import_android(import_path)
       doc = REXML::Document.new(xml)
 
       doc.elements.each('resources/string') { |str|
-        next if str.attributes['translatable'] == 'false'
+        next if str.attributes['translatable'] == 'false' and $skip_untranslatable_strings
 
         key = str.attributes['name']
         # puts "string: #{key}"
@@ -164,7 +170,7 @@ def import_android(import_path)
       }
 
       doc.elements.each('resources/string-array') { |arr|
-        next if arr.attributes['translatable'] == 'false'
+        next if arr.attributes['translatable'] == 'false' and $skip_untranslatable_strings
 
         key = arr.attributes['name']
         puts "string-array: #{key}"
@@ -183,7 +189,7 @@ def import_android(import_path)
       }
 
       doc.elements.each('resources/plurals') { |plu|
-        next if plu.attributes['translatable'] == 'false'
+        next if plu.attributes['translatable'] == 'false' and $skip_untranslatable_strings
 
         key = plu.attributes['name']
         puts "plurals: #{key}"

--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -399,7 +399,7 @@ def lookup_string_ref(locale, str)
   while str
     r = str.match(/^@string\/(.*)$/)
     break if not r
-    str = lookup_locales(locale, :string, r[1])
+    str = lookup_locales(locale, :strings, r[1])
   end
   return str if str
   return old

--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -408,6 +408,7 @@ end
 def export_ios_string(locale, str)
   str = lookup_string_ref(locale, str)
   str.gsub!(/"/, '\\"')
+  str.gsub!(/\n/, "\\n")
   return str
 end
 

--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -401,8 +401,8 @@ def lookup_string_ref(locale, str)
     break if not r
     str = lookup_locales(locale, :string, r[1])
   end
-  return str if str
-  return old
+  return str.clone if str
+  return old.clone
 end
 
 def export_ios_string(locale, str)


### PR DESCRIPTION
The current script contains a bug: missing translations are replaced by the base language. That's alright. However, those base translations get escaped multiple times, because your code processes the same String object multiple times by reference. E.g. "Foo" gets \\\\\\\"Foo\\\\\\\" instead of \\\"Foo\\\". You can fix this by copying the String values instead of using their references.