### PR TITLE
bugfix line breaks in iOS string files

### DIFF
--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -408,6 +408,7 @@ end
 def export_ios_string(locale, str)
   str = lookup_string_ref(locale, str)
   str.gsub!(/"/, '\\"')
+  str.gsub!(/\n/, "\\n")
   return str
 end
 


### PR DESCRIPTION
While the Android xml files may contain line breaks, they need to be replaced for the iOS strings.